### PR TITLE
Remove single-end libraries from user interface because they are invalid

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # Hipmer release notes
 =========================================
 
+0.1.6
+-----
+* Remove single-end libraries from user interface because they are invalid
+
 0.1.0
 -----
 * Update to new SDK and Python3

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.5
+    1.0.6
 
 owners:
     [scanon,dylan,jfroula]

--- a/ui/narrative/methods/run_hipmer_hpc/spec.json
+++ b/ui/narrative/methods/run_hipmer_hpc/spec.json
@@ -204,8 +204,6 @@
             "optional": false,
             "text_options": {
                 "valid_ws_types": [
-                    "KBaseAssembly.SingleEndLibrary",
-                    "KBaseFile.SingleEndLibrary",
                     "KBaseAssembly.PairedEndLibrary",
                     "KBaseFile.PairedEndLibrary"
                 ]


### PR DESCRIPTION
@scanon, @jfroula 
The user interface was still allowing users to add single-end libraries and they are no longer allowed.