### PR TITLE
Make input non-optional, fix the contact in the spec.json

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # Hipmer release notes
 =========================================
 
+1.1.1
+-----
+* Made input mandatory
+
 1.1.0
 -----
 * Added parameter to filter short length contigs from assembly

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.1.0
+    1.1.1
 
 owners:
     [scanon,dylan,jfroula,seanjungbluth]

--- a/ui/narrative/methods/run_hipmer_hpc/spec.json
+++ b/ui/narrative/methods/run_hipmer_hpc/spec.json
@@ -86,13 +86,13 @@
         "active",
         "assembly"
     ],
-    "contact": "help@kbase.us",
+    "contact": "http://kbase.us/contact-us/",
     "job_id_output_field": "docker",
     "parameter-groups": [
         {
             "id": "reads",
             "allow_multiple": true,
-            "optional": true,
+            "optional": false,
             "parameters": [
                 "read_library_name",
                 "ins_avg",


### PR DESCRIPTION
Change the input read library to be non-optional because the app doesn't check to verify that a input file exists. Without input, there is an uninformative error that doesn't tell what went wrong.

Related to https://kbase-jira.atlassian.net/browse/PTV-1401
@scanon, @jungbluth 