### PR TITLE
PTV-1908 Fix Catalog Secure Params

### DIFF
--- a/lib/hipmer/hipmerUtils.py
+++ b/lib/hipmer/hipmerUtils.py
@@ -106,7 +106,7 @@ class hipmerUtils:
 
     def _check_if_authorized_expert(self):
         if self.username not in self.authorized_expert_usernames:
-            raise Exception(f"You entered a GBP limit > 500 and your username {self.username} is not an authorized expert user. If believe you should be an expert user, please contact KBase.")
+            raise Exception(f"You entered a GBP limit greater than 500 and your username {self.username} is not authorized as an expert user. If you believe that you should be an expert user, please contact KBase.")
         
     
     def _validate_input_reads_sizelimit (self, refs, console, params):

--- a/lib/hipmer/hipmerUtils.py
+++ b/lib/hipmer/hipmerUtils.py
@@ -24,7 +24,7 @@ class hipmerUtils:
         self.scratch = os.path.abspath(config['scratch'])
         self.callbackURL = os.environ.get('SDK_CALLBACK_URL')
         self.username = user_id
-        self.authorized_expert_usernames = [username.strip() for username in os.environ.get("authorized_expert_usernames", "").split(",") if username.strip()]
+        self.authorized_expert_usernames = [username.strip() for username in os.environ.get("KBASE_SECURE_CONFIG_PARAM_authorized_expert_usernames", "").split(",") if username.strip()]
         self.wscli = workspaceService(config['workspace-url'], token=token)
         self.readcli = ReadsUtils(self.callbackURL, token=token)
         self.sr = special(self.callbackURL, token=token)
@@ -106,7 +106,7 @@ class hipmerUtils:
 
     def _check_if_authorized_expert(self):
         if self.username not in self.authorized_expert_usernames:
-            raise Exception(f"You entered a GBP limit > 500 and your username {self.username} is not an authorized expert user {self.authorized_expert_usernames}. If believe you should be an expert user, please contact KBase. {os.environ}")
+            raise Exception(f"You entered a GBP limit > 500 and your username {self.username} is not an authorized expert user. If believe you should be an expert user, please contact KBase.")
         
     
     def _validate_input_reads_sizelimit (self, refs, console, params):

--- a/lib/hipmer/hipmerUtils.py
+++ b/lib/hipmer/hipmerUtils.py
@@ -106,7 +106,7 @@ class hipmerUtils:
 
     def _check_if_authorized_expert(self):
         if self.username not in self.authorized_expert_usernames:
-            raise Exception(f"You entered a GBP limit > 500 and you are not an authorized expert user {self.authorized_expert_usernames}. If you username:{self.username} believe you should be an expert user, please contact KBase")
+            raise Exception(f"You entered a GBP limit > 500 and your username {self.username} is not an authorized expert user {self.authorized_expert_usernames}. If believe you should be an expert user, please contact KBase. {os.environ}")
         
     
     def _validate_input_reads_sizelimit (self, refs, console, params):

--- a/lib/hipmer/hipmerUtils.py
+++ b/lib/hipmer/hipmerUtils.py
@@ -24,8 +24,7 @@ class hipmerUtils:
         self.scratch = os.path.abspath(config['scratch'])
         self.callbackURL = os.environ.get('SDK_CALLBACK_URL')
         self.username = user_id
-        self.authorized_expert_usernames = os.environ.get("authorized_expert_usernames","").split(",")
-        print(config['service-wizard'])
+        self.authorized_expert_usernames = [username.strip() for username in os.environ.get("authorized_expert_usernames", "").split(",") if username.strip()]
         self.wscli = workspaceService(config['workspace-url'], token=token)
         self.readcli = ReadsUtils(self.callbackURL, token=token)
         self.sr = special(self.callbackURL, token=token)
@@ -107,7 +106,7 @@ class hipmerUtils:
 
     def _check_if_authorized_expert(self):
         if self.username not in self.authorized_expert_usernames:
-            raise Exception("You entered a GBP limit > 500 and you are not an authorized expert user. If you believe you should be an expert user, please contact KBase")
+            raise Exception(f"You entered a GBP limit > 500 and you are not an authorized expert user. If you {self.username} believe you should be an expert user, please contact KBase")
         
     
     def _validate_input_reads_sizelimit (self, refs, console, params):

--- a/lib/hipmer/hipmerUtils.py
+++ b/lib/hipmer/hipmerUtils.py
@@ -106,7 +106,7 @@ class hipmerUtils:
 
     def _check_if_authorized_expert(self):
         if self.username not in self.authorized_expert_usernames:
-            raise Exception(f"You entered a GBP limit > 500 and you are not an authorized expert user. If you {self.username} believe you should be an expert user, please contact KBase")
+            raise Exception(f"You entered a GBP limit > 500 and you are not an authorized expert user {self.authorized_expert_usernames}. If you username:{self.username} believe you should be an expert user, please contact KBase")
         
     
     def _validate_input_reads_sizelimit (self, refs, console, params):


### PR DESCRIPTION
CSPs not working at the moment.

This pr
* Fixes it to use the correct env
* Removes whitespace from the env

```
  File "/kb/module/lib/hipmer/hipmerUtils.py", line 109, in _check_if_authorized_expert
    raise Exception(f"You entered a GBP limit > 500 and you are not an authorized expert user {self.authorized_expert_usernames}. If you username:{self.username} believe you should be an expert user, please contact KBase")
Exception: You entered a GBP limit > 500 and you are not an authorized expert user []. If you username:bioboris believe you should be an expert user, please contact KBase
```


```
{
  "KB_TOP": "/kb/deployment",
  "HOSTNAME": "d9d3b5a9ea9b",
  "SHLVL": "1",
  "HOME": "/root",
  "KB_DEPLOYMENT_CONFIG": "/kb/module/scripts/../deploy.cfg",
  "SDK_CALLBACK_URL": "http://123.123.123:123/",
  "JAVA_VERSION": "8u181",
  "_": "/bin/sh",
  "CA_CERTIFICATES_JAVA_VERSION": "20170531+nmu1",
  "JAVA_DEBIAN_VERSION": "8u181-b13-1~deb9u1",
  "PATH": "/miniconda/bin:/kb/deployment/bin:/kb/runtime/bin:/miniconda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
  "ANT_HOME": "/usr/share/ant",
  "PERL5LIB": "/kb/deployment/lib:/kb/deployment/lib/perl5",
  "LANG": "C.UTF-8",
  "JETTY_HOME": "/usr/share/jetty9",
  "JAVA_HOME": "/docker-java-home",
  "PWD": "/kb/module",
  "KB_PERL_PATH": "/kb/deployment/lib",
  "KB_RUNTIME": "/kb/runtime",
  "PYTHONPATH": "/kb/module/bin/../lib:/miniconda/bin:/kb/deployment/bin:/kb/runtime/bin:/miniconda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/kb/deployment/lib:/kb/deployment/lib",
  "KBASE_SECURE_CONFIG_PARAM_authorized_expert_usernames": "super_cool_person,kbasehelp",
  "KB_AUTH_TOKEN": "<redacted>"
}
```

I registered this in CI and APPDEV and it worked, now it does not crash and say I am unauthorized when I put > 500 in the GBPS field because I am authorized!



Config
<img width="1163" alt="image" src="https://github.com/kbaseapps/kbase_hipmer/assets/1258634/4ba02f1e-b54d-4d64-83f1-7bcd83c32b5e">



No longer happens:
<img width="1165" alt="image" src="https://github.com/kbaseapps/kbase_hipmer/assets/1258634/e54c4e03-87e6-4260-a919-2b62ed7c3f13">



